### PR TITLE
Fix: NameError due to undefined `folder_name` in stage1_sample_ddp.py

### DIFF
--- a/src/stage1_sample_ddp.py
+++ b/src/stage1_sample_ddp.py
@@ -126,12 +126,11 @@ def main(args):
         f"bs{args.per_proc_batch_size}",
         args.precision,
     ]
-    sample_folder_dir = os.path.join(args.sample_dir, "-".join(folder_components))
+    folder_name = "-".join(folder_components)
     possible_folder_name = os.environ.get('SAVE_FOLDER', None)
     if possible_folder_name:
-        sample_folder_dir = os.path.join(args.sample_dir, possible_folder_name)
-    else:
-        sample_folder_dir = os.path.join(args.sample_dir, folder_name)
+        folder_name = possible_folder_name
+    sample_folder_dir = os.path.join(args.sample_dir, folder_name)
     if rank == 0:
         os.makedirs(sample_folder_dir, exist_ok=True)
         print(f"Saving reconstructed samples at {sample_folder_dir}")


### PR DESCRIPTION
## Problem
  Running `stage1_sample_ddp.py` raises `NameError: name 'folder_name' is not defined` at line 134.

  ## Cause
  The variable `folder_name` was referenced in the else branch but was never defined.

  ## Fix
  Properly define `folder_name` from `folder_components` before the conditional check.

  **Before:**
  ```python
  sample_folder_dir = os.path.join(args.sample_dir, "-".join(folder_components))
  possible_folder_name = os.environ.get('SAVE_FOLDER', None)
  if possible_folder_name:
      sample_folder_dir = os.path.join(args.sample_dir, possible_folder_name)
  else:
      sample_folder_dir = os.path.join(args.sample_dir, folder_name)  # BUG: folder_name undefined
```
 **After:**
 ```python
  folder_name = "-".join(folder_components)
  possible_folder_name = os.environ.get('SAVE_FOLDER', None)
  if possible_folder_name:
      folder_name = possible_folder_name
  sample_folder_dir = os.path.join(args.sample_dir, folder_name)
```